### PR TITLE
Add racial skill option

### DIFF
--- a/Order.js
+++ b/Order.js
@@ -46,3 +46,22 @@ Hooks.once("init", function () {
 
   preloadHandlebarsTemplates();
 });
+
+Hooks.on("preCreateItem", async (item, data, options, userId) => {
+  if (data.type !== "Skill" || !options?.renderSheet) return;
+  const isRacial = await new Promise((resolve) => {
+    new Dialog({
+      title: "Тип навыка",
+      content: `<div class="form-group"><label><input type="checkbox" name="isRacial"/> Рассовый скилл</label></div>`,
+      buttons: {
+        ok: {
+          label: "OK",
+          callback: (html) => resolve(html.find('input[name="isRacial"]').is(":checked"))
+        }
+      },
+      default: "ok",
+      close: () => resolve(false)
+    }).render(true);
+  });
+  item.updateSource({ "system.isRacial": isRacial });
+});

--- a/template.json
+++ b/template.json
@@ -232,7 +232,8 @@
         "stats"
       ],
       "Cooldown": 1,
-      "Multiplier": 0
+      "Multiplier": 0,
+      "isRacial": false
     },
     "Spell": {
       "templates": [

--- a/templates/sheets/Skill-sheet.hbs
+++ b/templates/sheets/Skill-sheet.hbs
@@ -5,14 +5,20 @@
             <input name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'Name' }}" />
         </h1>
     </header>
+    <div class="form-group">
+        <label for="isRacial">Рассовый скилл</label>
+        <input type="checkbox" name="data.isRacial" {{#if data.isRacial}}checked{{/if}} class="is-racial-checkbox" />
+    </div>
+    {{#unless data.isRacial}}
     <div class="skill-level">
-  <canvas 
-    class="circle-progress-skill" 
-    data-circle="{{data.Circle}}" 
-    data-level="{{data.Level}}" 
+  <canvas
+    class="circle-progress-skill"
+    data-circle="{{data.Circle}}"
+    data-level="{{data.Level}}"
     data-filled="{{data.filledSegments}}"
   ></canvas>
 </div>
+    {{/unless}}
     <div class="sheet">
         <table>
             <tr>


### PR DESCRIPTION
## Summary
- add `isRacial` flag in skill template data
- allow toggling racial skill in skill sheet and hide training circle when racial
- prompt on skill creation to mark as racial

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f58263fb0832cad61d7c89e30766d