### PR TITLE
Fix drag-and-drop inventory

### DIFF
--- a/Order.css
+++ b/Order.css
@@ -175,3 +175,104 @@
 .modifiers-wrapper:hover .modifiers-tooltip {
   display: block;
 }
+
+.inventory-capacity {
+  margin-bottom: 1em;
+}
+
+.inventory-warning {
+  color: red;
+  font-weight: bold;
+}
+
+.inventory-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 35px);
+  gap: 10px;
+  padding: 10px;
+}
+
+.inventory-slot {
+  position: relative;
+  width: 35px;
+  height: 35px;
+  border: 1px solid black;
+  border-radius: 2px;
+  text-align: center;
+}
+
+.inventory-slot .delete-item {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 18px;
+  height: 18px;
+  border: 1px solid white;
+  background: rgba(255, 0, 0, 0.8);
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  padding: 0;
+  z-index: 10;
+}
+
+.inventory-slot .delete-item:hover {
+  background: rgba(200, 0, 0, 1);
+  border-color: yellow;
+}
+
+.inventory-slot .delete-item i {
+  display: block;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  line-height: 18px;
+  font-size: 12px;
+  margin: 0;
+}
+
+.inventory-slot.empty {
+  background-color: rgba(0, 0, 0, 0.1);
+  border: 1px dashed gray;
+}
+
+.inventory-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.inventory-tooltip {
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 5px;
+  border-radius: 5px;
+  white-space: pre-wrap;
+  text-align: left;
+  line-height: 0.8;
+  font-size: 12px;
+  display: none;
+  z-index: 9999;
+  max-width: 250px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.7);
+  pointer-events: none;
+}
+
+.inventory-slot.quick {
+  border-color: green;
+}
+
+.inventory-slot.carry {
+  border-color: blue;
+}
+
+.inventory-slot.over {
+  border-color: gray;
+  opacity: 0.5;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -11,7 +11,9 @@
       "Deffensepotential": "Deffensepotential",
       "Parameters": "Parameters",
       "Requires": "Requires",
-      "Modificationslots": "Modification slots"
+      "Modificationslots": "Modification slots",
+      "inventorySlots": "Inventory slots",
+      "quickAccessSlots": "Quick access slots"
     },
     "attackType": {
       "none": "",

--- a/module/config.js
+++ b/module/config.js
@@ -12,6 +12,8 @@ Order.Armor = {
   Parameters: "Order.Armor.Parameters",
   Requires: "Order.Armor.Requires",
   Modificationslots: "Order.Armor.Modificationslots",
+  inventorySlots: "Order.Armor.inventorySlots",
+  quickAccessSlots: "Order.Armor.quickAccessSlots",
 };
 
 Order.Caracteristics = {

--- a/module/sheets/OrderPlayerSheet.js
+++ b/module/sheets/OrderPlayerSheet.js
@@ -10,7 +10,7 @@ export default class OrderPlayerSheet extends ActorSheet {
     const baseData = super.getData();
     const actorData = baseData.actor || {};
     const systemData = actorData.system || {};
-    const items = baseData.items || [];
+    const items = this.actor.items ? Array.from(this.actor.items) : [];
     const playerColor = game.user.color || "#ffffff";
     // Получаем эффекты актора
     const activeEffects = baseData.effects;
@@ -32,6 +32,31 @@ export default class OrderPlayerSheet extends ActorSheet {
       RegularItems: items.filter(item => item.type === "RegularItem"),
       effects: activeEffects // Включаем эффекты в данные
     };
+
+    const inventoryItems = [
+      ...sheetData.weapons,
+      ...sheetData.armors,
+      ...sheetData.Consumables,
+      ...sheetData.RegularItems
+    ];
+
+    const carryItems = inventoryItems.filter(i => (i.getFlag("Order", "slotType") || "carry") === "carry");
+    const quickItems = inventoryItems.filter(i => i.getFlag("Order", "slotType") === "quick");
+    const overItems = inventoryItems.filter(i => i.getFlag("Order", "slotType") === "over");
+
+    const slots = [];
+    const carrySlots = systemData.inventorySlots || 0;
+    const quickSlots = systemData.quickAccessSlots || 0;
+
+    carryItems.forEach(it => slots.push({ item: it, slotType: "carry", empty: false }));
+    for (let i = carryItems.length; i < carrySlots; i++) slots.push({ item: null, slotType: "carry", empty: true });
+
+    quickItems.forEach(it => slots.push({ item: it, slotType: "quick", empty: false }));
+    for (let i = quickItems.length; i < quickSlots; i++) slots.push({ item: null, slotType: "quick", empty: true });
+
+    overItems.forEach(it => slots.push({ item: it, slotType: "over", empty: false }));
+
+    sheetData.inventoryGrid = slots;
 
     console.log("Data in getData():", baseData);
     console.log("Data after adding config:", sheetData);
@@ -313,6 +338,100 @@ export default class OrderPlayerSheet extends ActorSheet {
           left: offset.left - activeTooltip.outerWidth() - 10 + "px", // Слева от карточки
         });
       }
+    });
+
+    // Инвентарь: открытие предмета по двойному клику
+    html.find(".inventory-slot[data-item-id]").on("dblclick", (event) => {
+      const itemId = event.currentTarget.dataset.itemId;
+      const item = this.actor.items.get(itemId);
+      if (item) item.sheet.render(true);
+    });
+
+    // Подсказка для предметов инвентаря
+    html.find(".inventory-slot[data-item-id]").on("mouseenter", (event) => {
+      const target = $(event.currentTarget);
+      const tooltip = target.find(".inventory-tooltip");
+
+      if (activeTooltip) {
+        activeTooltip.remove();
+        activeTooltip = null;
+      }
+
+      tooltip.hide();
+      const offset = target.offset();
+      activeTooltip = tooltip.clone()
+        .appendTo("body")
+        .addClass("active-tooltip")
+        .css({
+          top: offset.top + "px",
+          left: offset.left - tooltip.outerWidth() - 10 + "px",
+          position: "absolute",
+          display: "block",
+          zIndex: 9999,
+        });
+    });
+
+    html.find(".inventory-slot[data-item-id]").on("mouseleave", () => {
+      if (activeTooltip) {
+        activeTooltip.remove();
+        activeTooltip = null;
+      }
+    });
+
+    html.find(".inventory-slot[data-item-id]").on("mousemove", (event) => {
+      if (activeTooltip) {
+        const offset = $(event.currentTarget).offset();
+        activeTooltip.css({
+          top: offset.top + "px",
+          left: offset.left - activeTooltip.outerWidth() - 10 + "px",
+        });
+      }
+    });
+
+    // Drag-and-drop relocation of inventory items
+    html.find(".inventory-icon[item-draggable]").on("dragstart", ev => {
+      const slot = ev.currentTarget.closest(".inventory-slot");
+      const id = slot.dataset.itemId;
+      const fromType = slot.dataset.slotType;
+      if (activeTooltip) {
+        activeTooltip.remove();
+        activeTooltip = null;
+      }
+      if (id)
+        ev.originalEvent.dataTransfer.setData(
+          "text/plain",
+          JSON.stringify({ id, fromType })
+        );
+    });
+    html.find(".inventory-slot").on("dragover", ev => ev.preventDefault());
+    html.find(".inventory-slot").on("drop", async ev => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      let data;
+      try {
+        data = JSON.parse(ev.originalEvent.dataTransfer.getData("text/plain"));
+      } catch (e) {
+        return;
+      }
+      const { id, fromType } = data || {};
+      const targetType = ev.currentTarget.dataset.slotType;
+      const targetId = ev.currentTarget.dataset.itemId;
+      if (!id || !targetType) return;
+
+      if (activeTooltip) {
+        activeTooltip.remove();
+        activeTooltip = null;
+      }
+
+      const item = this.actor.items.get(id);
+      const promises = [];
+      if (item) promises.push(item.setFlag("Order", "slotType", targetType));
+      if (targetId && targetId !== id) {
+        const other = this.actor.items.get(targetId);
+        if (other) promises.push(other.setFlag("Order", "slotType", fromType));
+      }
+      if (promises.length) await Promise.all(promises);
+      this.render();
     });
 
 
@@ -1295,6 +1414,10 @@ Handlebars.registerHelper("mod", function (a, b) {
 
 Handlebars.registerHelper("sub", function (a, b) {
   return a - b;
+});
+
+Handlebars.registerHelper("add", function(a, b) {
+  return (Number(a) || 0) + (Number(b) || 0);
 });
 
 Handlebars.registerHelper("let", function (...args) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Order",
+  "name": "OrderSystemForFaundry",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/scripts/OrderActor.js
+++ b/scripts/OrderActor.js
@@ -4,8 +4,8 @@ export class OrderActor extends Actor {
       super.prepareData();
       this._prepareOrderActorData();
     }
-  
-    _prepareOrderActorData() {
+
+    async _prepareOrderActorData() {
       if (this.type !== "Player") return;
   
       const system = this.system;
@@ -63,6 +63,83 @@ export class OrderActor extends Actor {
     const dexVal = system?.Dexterity?.value || 0;
     system.Movement.value = 3 + Math.ceil(dexVal / 2);
 
+    // ------------------------------
+    // 4. Inventory and Carrying Capacity
+    // ------------------------------
+    const equippedArmor = this.items.find(i => i.type === "Armor" && i.system.isEquiped);
+    const inventorySlots = equippedArmor ? Number(equippedArmor.system.inventorySlots || 0) : 0;
+    const quickSlots = equippedArmor ? Number(equippedArmor.system.quickAccessSlots || 0) : 0;
+    system.inventorySlots = inventorySlots;
+    system.quickAccessSlots = quickSlots;
+    const maxInventory = inventorySlots + quickSlots;
+
+    const inventoryItems = this.items.filter(i => ["weapon","meleeweapon","rangeweapon","Armor","Consumables","RegularItem"].includes(i.type));
+    const itemCount = inventoryItems.length;
+    system.inventoryCount = itemCount;
+    system.inventoryOver = itemCount > maxInventory;
+
+    const carryingCapacity = Math.max(5, 5 + staminaVal);
+    system.carryingCapacity = carryingCapacity;
+    const exceed = itemCount - carryingCapacity;
+
+    await this._handleOverloadEffects(exceed, itemCount, maxInventory);
+    }
+
+    async _handleOverloadEffects(exceed, itemCount, maxInventory) {
+      if (this._processingOverload) return;
+
+      const flags = this.flags?.Order || {};
+      let level = flags.overloadLevel || 0;
+
+      let newLevel = 0;
+      if (exceed >= 1 && exceed <= 2) newLevel = 1;
+      else if (exceed >= 3 && exceed <= 6) newLevel = 2;
+      else if (exceed >= 7 && exceed <= 12) newLevel = 3;
+      else if (exceed >= 13) newLevel = 4;
+
+      if (level === newLevel && this.getFlag("Order", "inventoryOver") === (itemCount > maxInventory)) return;
+
+      this._processingOverload = true;
+
+      // Remove previous effects if level changed or inventory notification changed
+      const remove = this.effects.filter(e => ["Увязший","Схваченный","Ошеломление"].includes(e.label)).map(e => e.id);
+      if (remove.length) await this.deleteEmbeddedDocuments("ActiveEffect", remove);
+
+      // Apply new effects based on newLevel
+      if (newLevel === 1) {
+        await this._applyDebuff("Stuck", "1");
+      } else if (newLevel === 2) {
+        await this._applyDebuff("Captured", "1");
+      } else if (newLevel === 3) {
+        await this._applyDebuff("Captured", "2");
+      } else if (newLevel === 4) {
+        await this._applyDebuff("Captured", "2");
+        await this._applyDebuff("Dizziness", "1");
+      }
+
+      await this.update({ "flags.Order.overloadLevel": newLevel, "flags.Order.inventoryOver": itemCount > maxInventory });
+
+      this._processingOverload = false;
+    }
+
+    async _applyDebuff(key, state) {
+      try {
+        const response = await fetch("systems/Order/module/debuffs.json");
+        if (!response.ok) throw new Error("Failed to load debuffs");
+        const data = await response.json();
+        const debuff = data[key];
+        if (!debuff || !debuff.states[state]) return;
+        const effectData = {
+          label: debuff.name,
+          icon: "icons/svg/skull.svg",
+          changes: debuff.changes[state] || [],
+          duration: { rounds: 1 },
+          flags: { description: debuff.states[state], debuff: key, state }
+        };
+        await this.createEmbeddedDocuments("ActiveEffect", [effectData]);
+      } catch (err) {
+        console.error(err);
+      }
     }
   }
   

--- a/template.json
+++ b/template.json
@@ -134,7 +134,11 @@
       ],
       "class": "",
       "Rank": 1,
-      "SelfInfo" : "" 
+      "SelfInfo" : "",
+      "carryingCapacity": 5,
+      "inventorySlots": 0,
+      "quickAccessSlots": 0,
+      "overloadLevel": 0
     },
     "NPC": {
       "templates": [
@@ -216,6 +220,8 @@
       "RequiresArray" : [],
       "Modificationslots": 0,
       "additionalAdvantages": [],
+      "inventorySlots": 0,
+      "quickAccessSlots": 0,
       "isEquiped" : false,
       "isUsed": false
     },

--- a/templates/partials/inventory-slot.hbs
+++ b/templates/partials/inventory-slot.hbs
@@ -1,0 +1,20 @@
+<div class="inventory-slot item {{slotType}} {{#if empty}}empty{{/if}}" data-slot-type="{{slotType}}" {{#if item}}data-item-id="{{item._id}}"{{/if}}>
+  {{#if item}}
+    <button class="delete-item item-delete" title="Удалить предмет" type="button">
+      <i class="fas fa-times"></i>
+    </button>
+    <img class="inventory-icon" src="{{item.img}}" alt="{{item.name}}" item-draggable draggable="true">
+    <div class="inventory-tooltip">
+      <p>{{item.name}}</p>
+      {{#if item.system.Description}}
+        <p>{{item.system.Description}}</p>
+      {{/if}}
+      {{#if item.system.Damage}}
+        <p><strong>Урон:</strong> {{item.system.Damage}}</p>
+      {{/if}}
+      {{#if item.system.Range}}
+        <p><strong>Дистанция:</strong> {{item.system.Range}}</p>
+      {{/if}}
+    </div>
+  {{/if}}
+</div>

--- a/templates/partials/inventory.hbs
+++ b/templates/partials/inventory.hbs
@@ -1,15 +1,15 @@
-{{#each weapons as |weapon id|}}
-    {{> "systems/Order/templates/partials/weapon-card.hbs" weapon}}
-{{/each}}
+{{#let "maxSlots" (add @root.data.inventorySlots @root.data.quickAccessSlots)}}
+<div class="inventory-capacity">
+  <p>Грузоподъёмность: {{@root.data.inventoryCount}} / {{@root.data.carryingCapacity}}</p>
+  <p>Вместимость: {{@root.data.inventoryCount}} / {{maxSlots}}</p>
+  {{#if (gt @root.data.inventoryCount maxSlots)}}
+    <p class="inventory-warning">Инвентарь переполнен!</p>
+  {{/if}}
+</div>
+{{/let}}
 
-{{#each armors as |Armor id|}}
-    {{> "systems/Order/templates/partials/armor-card.hbs" Armor}}
-{{/each}}
-
-{{#each Consumables as |Consumable id|}}
-    {{> "systems/Order/templates/partials/consumables-card.hbs" Consumable}}
-{{/each}}
-
-{{#each RegularItems as |RegularItem id|}}
-    {{> "systems/Order/templates/partials/regularItem-card.hbs" RegularItem}}
-{{/each}}
+<div class="inventory-grid">
+  {{#each inventoryGrid as |slot i|}}
+    {{> "systems/Order/templates/partials/inventory-slot.hbs" item=slot.item slotType=slot.slotType empty=slot.empty}}
+  {{/each}}
+</div>

--- a/templates/sheets/Armor-sheet.hbs
+++ b/templates/sheets/Armor-sheet.hbs
@@ -20,6 +20,8 @@
         <th>Параметры</th>
         <th>Требования</th>
         <th>Слоты модификаци</th>
+        <th>Ячейки инвентаря</th>
+        <th>Быстрый доступ</th>
       </tr>
       <tr>
         <td><input name="data.Deffensepotential" type="text" value="{{data.Deffensepotential}}" data-type="Number" />
@@ -57,6 +59,8 @@
         </td>
         <td><input name="data.Modificationslots" type="text" value="{{data.Modificationslots}}" data-type="Number" />
         </td>
+        <td><input name="data.inventorySlots" type="number" value="{{data.inventorySlots}}" min="0" /></td>
+        <td><input name="data.quickAccessSlots" type="number" value="{{data.quickAccessSlots}}" min="0" /></td>
       </tr>
     </table>
     <textarea name="data.description">{{data.description}}</textarea>


### PR DESCRIPTION
## Summary
- move inventory delete button to top-right
- make items draggable from the icon only
- allow swapping items across inventory slots
- close the tooltip on drag and drop

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68535c4c01c8832c80c203dd63fc05a1