### PR TITLE
Add controls to adjust applied debuff levels

### DIFF
--- a/module/sheets/OrderPlayerSheet.js
+++ b/module/sheets/OrderPlayerSheet.js
@@ -636,6 +636,8 @@ export default class OrderPlayerSheet extends ActorSheet {
     html.find('.is-equiped-checkbox').change(this._onEquipChange.bind(this));
     html.find('.apply-debuff').click(() => this._openDebuffDialog(this.actor));
     html.find('.remove-effect').click(this._onRemoveEffect.bind(this));
+    html.find('.effect-level-increase').click(ev => this._onAdjustEffectLevel(ev, 1));
+    html.find('.effect-level-decrease').click(ev => this._onAdjustEffectLevel(ev, -1));
     this._activateCircleListeners(html);
     this._initializeTabs(html);
   }
@@ -1644,19 +1646,8 @@ export default class OrderPlayerSheet extends ActorSheet {
   }
 
   async _openDebuffDialog(actor) {
-    let systemStates = {};
-
-    try {
-      // Ждем, пока JSON-файл будет загружен
-      const response = await fetch("systems/Order/module/debuffs.json");
-      if (!response.ok) throw new Error("Failed to load debuffs.json");
-      systemStates = await response.json();
-
-    } catch (err) {
-      console.error(err);
-      ui.notifications.error("Не удалось загрузить состояния дебаффов.");
-      return;
-    }
+    const systemStates = await this._fetchDebuffData();
+    if (!systemStates) return;
 
     // Получаем ключи дебаффов
     const debuffKeys = Object.keys(systemStates);
@@ -1700,41 +1691,108 @@ export default class OrderPlayerSheet extends ActorSheet {
 
 
   async applyDebuff(actor, debuffKey, stateKey) {
-
-    let systemStates = {};
-
-    try {
-      // Ждем, пока JSON-файл будет загружен
-      const response = await fetch("systems/Order/module/debuffs.json");
-      if (!response.ok) throw new Error("Failed to load debuffs.json");
-      systemStates = await response.json();
-
-    } catch (err) {
-      console.error(err);
-      ui.notifications.error("Не удалось загрузить состояния дебаффов.");
-      return;
-    }
+    const systemStates = await this._fetchDebuffData();
+    if (!systemStates) return;
 
     const debuff = systemStates[debuffKey];
     if (!debuff || !debuff.states[stateKey]) {
       ui.notifications.error("Invalid debuff or state");
       return;
     }
-    const stageChanges = Array.isArray(debuff.changes?.[stateKey]) ? debuff.changes[stateKey] : [];
+    const stageChanges = Array.isArray(debuff.changes?.[stateKey])
+      ? debuff.changes[stateKey].map(change => ({ ...change }))
+      : [];
 
-    const effectData = {
+    const maxState = Object.keys(debuff.states || {}).length;
+    const existingEffect = actor.effects.find(e => e.getFlag("order", "debuffKey") === debuffKey);
+
+    const updateData = {
+      changes: stageChanges,
       label: `${debuff.name}`,
-      icon: "icons/svg/skull.svg", // Добавьте соответствующую иконку
-      changes: stageChanges, // Здесь можно добавить изменения на основе логики
-      duration: {
-        rounds: 1 // Пример длительности
-      },
-      flags: {
-        description: debuff.states[stateKey]
-      }
+      'flags.description': debuff.states[stateKey],
+      'flags.order.debuffKey': debuffKey,
+      'flags.order.stateKey': Number(stateKey),
+      'flags.order.maxState': maxState
     };
 
-    actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
+    if (existingEffect) {
+      await existingEffect.update(updateData);
+    } else {
+      const effectData = {
+        label: `${debuff.name}`,
+        icon: "icons/svg/skull.svg", // Добавьте соответствующую иконку
+        changes: stageChanges,
+        duration: {
+          rounds: 1 // Пример длительности
+        },
+        flags: {
+          description: debuff.states[stateKey],
+          order: {
+            debuffKey,
+            stateKey: Number(stateKey),
+            maxState
+          }
+        }
+      };
+
+      await actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
+    }
+  }
+
+
+  async _onAdjustEffectLevel(event, delta) {
+    event.preventDefault();
+
+    const effectElement = event.currentTarget.closest(".effect-item");
+    const effectId = effectElement?.dataset.effectId;
+    if (!effectId) return;
+
+    const effect = this.actor.effects.get(effectId);
+    if (!effect) return;
+
+    const debuffKey = effect.getFlag("order", "debuffKey");
+    if (!debuffKey) {
+      ui.notifications.warn("Этот эффект нельзя изменить таким образом.");
+      return;
+    }
+
+    const systemStates = await this._fetchDebuffData();
+    if (!systemStates) return;
+
+    const debuff = systemStates[debuffKey];
+    if (!debuff) {
+      ui.notifications.error("Не удалось найти данные дебаффа.");
+      return;
+    }
+
+    const maxState = Object.keys(debuff.states || {}).length || effect.getFlag("order", "maxState") || 1;
+    const currentState = Number(effect.getFlag("order", "stateKey")) || 1;
+    const newState = Math.min(Math.max(currentState + delta, 1), maxState);
+
+    if (newState === currentState) return;
+
+    const stageChanges = Array.isArray(debuff.changes?.[newState])
+      ? debuff.changes[newState].map(change => ({ ...change }))
+      : [];
+
+    await effect.update({
+      changes: stageChanges,
+      'flags.description': debuff.states[newState],
+      'flags.order.stateKey': newState,
+      'flags.order.maxState': maxState
+    });
+  }
+
+  async _fetchDebuffData() {
+    try {
+      const response = await fetch("systems/Order/module/debuffs.json");
+      if (!response.ok) throw new Error("Failed to load debuffs.json");
+      return await response.json();
+    } catch (err) {
+      console.error(err);
+      ui.notifications.error("Не удалось загрузить состояния дебаффов.");
+      return null;
+    }
   }
 
 

--- a/module/sheets/OrderPlayerSheet.js
+++ b/module/sheets/OrderPlayerSheet.js
@@ -1704,15 +1704,15 @@ export default class OrderPlayerSheet extends ActorSheet {
       : [];
 
     const maxState = Object.keys(debuff.states || {}).length;
-    const existingEffect = actor.effects.find(e => e.getFlag("order", "debuffKey") === debuffKey);
+    const existingEffect = actor.effects.find(e => e.getFlag("Order", "debuffKey") === debuffKey);
 
     const updateData = {
       changes: stageChanges,
       label: `${debuff.name}`,
       'flags.description': debuff.states[stateKey],
-      'flags.order.debuffKey': debuffKey,
-      'flags.order.stateKey': Number(stateKey),
-      'flags.order.maxState': maxState
+      'flags.Order.debuffKey': debuffKey,
+      'flags.Order.stateKey': Number(stateKey),
+      'flags.Order.maxState': maxState
     };
 
     if (existingEffect) {
@@ -1727,7 +1727,7 @@ export default class OrderPlayerSheet extends ActorSheet {
         },
         flags: {
           description: debuff.states[stateKey],
-          order: {
+          Order: {
             debuffKey,
             stateKey: Number(stateKey),
             maxState
@@ -1750,7 +1750,7 @@ export default class OrderPlayerSheet extends ActorSheet {
     const effect = this.actor.effects.get(effectId);
     if (!effect) return;
 
-    const debuffKey = effect.getFlag("order", "debuffKey");
+    const debuffKey = effect.getFlag("Order", "debuffKey");
     if (!debuffKey) {
       ui.notifications.warn("Этот эффект нельзя изменить таким образом.");
       return;
@@ -1765,8 +1765,8 @@ export default class OrderPlayerSheet extends ActorSheet {
       return;
     }
 
-    const maxState = Object.keys(debuff.states || {}).length || effect.getFlag("order", "maxState") || 1;
-    const currentState = Number(effect.getFlag("order", "stateKey")) || 1;
+    const maxState = Object.keys(debuff.states || {}).length || effect.getFlag("Order", "maxState") || 1;
+    const currentState = Number(effect.getFlag("Order", "stateKey")) || 1;
     const newState = Math.min(Math.max(currentState + delta, 1), maxState);
 
     if (newState === currentState) return;
@@ -1778,8 +1778,8 @@ export default class OrderPlayerSheet extends ActorSheet {
     await effect.update({
       changes: stageChanges,
       'flags.description': debuff.states[newState],
-      'flags.order.stateKey': newState,
-      'flags.order.maxState': maxState
+      'flags.Order.stateKey': newState,
+      'flags.Order.maxState': maxState
     });
   }
 

--- a/templates/sheets/Player-sheet.hbs
+++ b/templates/sheets/Player-sheet.hbs
@@ -89,10 +89,10 @@
               <div class="effect-details">
                 <strong>{{this.name}}</strong>
                 <p>{{this.flags.description}}</p>
-                {{#if this.flags.order}}
+                {{#if this.flags.Order}}
                 <div class="effect-level-controls">
                   <button class="effect-level-decrease" type="button" aria-label="Понизить уровень дебаффа">-</button>
-                  <span class="effect-level-display">{{this.flags.order.stateKey}}</span>
+                  <span class="effect-level-display">{{this.flags.Order.stateKey}}</span>
                   <button class="effect-level-increase" type="button" aria-label="Повысить уровень дебаффа">+</button>
                 </div>
                 {{/if}}

--- a/templates/sheets/Player-sheet.hbs
+++ b/templates/sheets/Player-sheet.hbs
@@ -89,6 +89,13 @@
               <div class="effect-details">
                 <strong>{{this.name}}</strong>
                 <p>{{this.flags.description}}</p>
+                {{#if this.flags.order}}
+                <div class="effect-level-controls">
+                  <button class="effect-level-decrease" type="button" aria-label="Понизить уровень дебаффа">-</button>
+                  <span class="effect-level-display">{{this.flags.order.stateKey}}</span>
+                  <button class="effect-level-increase" type="button" aria-label="Повысить уровень дебаффа">+</button>
+                </div>
+                {{/if}}
                 <button class="remove-effect" type="button" data-effect-id="{{this._id}}">Удалить</button>
               </div>
             </li>


### PR DESCRIPTION
## Summary
- reuse a shared loader for debuff definitions and store metadata on created effects
- allow reapplying existing debuffs to update their level without recreating the effect
- expose +/- controls in the sheet to adjust debuff levels directly

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb3182db44832cab3f45292b198bc8